### PR TITLE
11 minimal container runtime configuration

### DIFF
--- a/.github/workflows/run0.yaml
+++ b/.github/workflows/run0.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 
 .idea
 *.tar.gz
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8057bb0f33d7ecdf1f0f7cc74ea5cced7c6c694245e2a8d14700507c3bde32e3"
+checksum = "6b409d52fff741f330914aa6b8ab73e9113607bb13fbc09f95cdb04d16c8dd5d"
 dependencies = [
  "derive_builder",
  "getset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,8 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "oci-spec",
+ "serde",
+ "serde_json",
  "unshare",
 ]
 
@@ -204,6 +206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "kaps"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "container",
+ "oci-spec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,14 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "run0"
-version = "0.1.0"
-dependencies = [
- "clap",
- "container",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Polytech Montpellier - DevOps"]
 [dependencies]
 clap = { version = "3.0.5", features = ["derive"] }
 container = { path = "container" }
+oci-spec = "0.5.3"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ oci-spec = "0.5.3"
 
 [workspace]
 members = [
-        "container"
+ "container"
 ]

--- a/container/Cargo.toml
+++ b/container/Cargo.toml
@@ -8,3 +8,5 @@ authors = ["Polytech Montpellier - DevOps"]
 lazy_static = "1.4.0"
 oci-spec = "0.5.3"
 unshare = { git = "https://github.com/virt-do/unshare", branch = "main" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -11,6 +11,7 @@ mod command;
 mod environment;
 mod mounts;
 mod namespaces;
+pub mod spec;
 
 /// Containers related errors
 #[derive(Debug)]

--- a/container/src/spec.rs
+++ b/container/src/spec.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use oci_spec::image::ImageConfiguration;
+use oci_spec::runtime::{Process, Spec, SpecBuilder};
+use oci_spec::OciSpecError;
+
+use oci_spec::image::ANNOTATION_CREATED;
+
+pub const BUNDLE_CONFIG: &str = "config.json";
+
+pub type Result<T> = std::result::Result<T, OciSpecError>;
+
+/// Generate a runtime config and return his path
+pub fn new_runtime_config(image_config: Option<&ImageConfiguration>) -> Result<Spec> {
+    if let Some(image_config) = image_config {
+        let annotations = build_annotations(image_config);
+        let process = build_process(image_config);
+
+        Ok(SpecBuilder::default()
+            .version(String::from("1.0"))
+            .process(process)
+            .annotations(annotations)
+            .build()?)
+    } else {
+        Ok(Spec::default())
+    }
+}
+
+/// Build process from an image configuration and return it
+fn build_process(image_config: &ImageConfiguration) -> Process {
+    let mut args: Vec<String> = vec![];
+    let mut process = Process::default();
+
+    if let Some(config) = image_config.config() {
+        if let Some(entrypoint) = config.entrypoint() {
+            args.extend(entrypoint.clone());
+        }
+        if let Some(cmd) = config.cmd() {
+            args.extend(cmd.clone());
+        }
+        if let Some(env) = config.env() {
+            process.set_env(Some(env.to_vec()));
+        }
+        if let Some(working_dir) = config.working_dir() {
+            process.set_cwd(PathBuf::from(working_dir));
+        }
+        if !args.is_empty() {
+            process.set_args(Some(args));
+        }
+    }
+    process
+}
+
+/// Build annotations from an image configuration and return it
+fn build_annotations(image_config: &ImageConfiguration) -> HashMap<String, String> {
+    let mut annotations: HashMap<String, String> = HashMap::new();
+
+    if let Some(created) = image_config.created() {
+        annotations.insert(ANNOTATION_CREATED.to_string(), created.to_string());
+    }
+
+    if let Some(config) = image_config.config() {
+        if let Some(labels) = config.labels() {
+            annotations.extend(labels.clone());
+        }
+    }
+    annotations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oci_spec::image::{ConfigBuilder, ImageConfigurationBuilder};
+
+    #[test]
+    fn test_process_config() -> Result<()> {
+        let image_config = ImageConfigurationBuilder::default()
+            .config(
+                ConfigBuilder::default()
+                    .cmd(vec![String::from("-c"), String::from("ls")])
+                    .entrypoint(vec![String::from("bash")])
+                    .env(vec![String::from("PATH=/usr/local/sbin")])
+                    .working_dir(String::from("/home"))
+                    .build()?,
+            )
+            .build()?;
+
+        let spec = new_runtime_config(Some(&image_config));
+
+        assert!(spec.is_ok());
+
+        let spec = spec?;
+
+        assert!(spec.process().is_some());
+        if let Some(process) = spec.process() {
+            assert!(process.args().is_some());
+            if let Some(args) = process.args() {
+                assert_eq!(*args, ["bash", "-c", "ls"]);
+            }
+            assert!(process.env().is_some());
+            if let Some(env) = process.env() {
+                assert_eq!(*env, ["PATH=/usr/local/sbin"]);
+            }
+            assert!(process.cwd().to_str().is_some());
+            assert_eq!(process.cwd().to_str().unwrap(), "/home");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_annotations_config() -> Result<()> {
+        let image_config = ImageConfigurationBuilder::default()
+            .author("jhon")
+            .os("linux")
+            .architecture("amd64")
+            .created("01-12")
+            .config(
+                ConfigBuilder::default()
+                    .stop_signal("SIGKILL")
+                    .exposed_ports(vec![String::from("21/tcp")])
+                    .build()?,
+            )
+            .build()?;
+
+        let spec = new_runtime_config(Some(&image_config));
+
+        assert!(spec.is_ok());
+
+        let spec = spec?;
+
+        assert!(spec.annotations().is_some());
+        if let Some(annotations) = spec.annotations() {
+            let created = annotations.get_key_value(&ANNOTATION_CREATED.to_string());
+            assert!(created.is_some());
+            if let Some(created) = created {
+                assert_eq!(
+                    created,
+                    (&ANNOTATION_CREATED.to_string(), &String::from("01-12"))
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,12 +1,15 @@
 mod run;
+mod spec;
 
 use crate::cli::run::RunCommand;
+use crate::cli::spec::SpecCommand;
 use clap::{Parser, Subcommand};
 
 /// CLI related errors
 #[derive(Debug)]
 pub enum Error {
     Run(container::Error),
+    Spec(oci_spec::OciSpecError),
 }
 
 impl From<container::Error> for Error {
@@ -46,6 +49,7 @@ impl Cli {
     pub fn command(self) -> Box<dyn Handler> {
         match self.command {
             Command::Run(cmd) => Box::new(cmd),
+            Command::Spec(cmd) => Box::new(cmd),
         }
     }
 }
@@ -64,4 +68,7 @@ impl Cli {
 pub enum Command {
     /// Run a container
     Run(RunCommand),
+
+    /// Generate container spec
+    Spec(SpecCommand),
 }

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use crate::{Handler, Result};
+use clap::Args;
+use container::spec::{new_runtime_config, BUNDLE_CONFIG};
+use oci_spec::image::ImageConfiguration;
+
+use super::Error;
+
+#[derive(Debug, Args)]
+pub struct SpecCommand {}
+
+impl Handler for SpecCommand {
+    fn handler(&self) -> Result<()> {
+        let image_configuration = ImageConfiguration::default();
+        let spec = new_runtime_config(Some(&image_configuration)).map_err(Error::Spec)?;
+        let bundle_config = PathBuf::from(".").join(BUNDLE_CONFIG);
+        spec.save(&bundle_config).map_err(Error::Spec)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to add a command to generate a container specification like `runc spec`

1. I have created a lib that exposes a method to create the config.json file. This lib will be used by @thomasgouveia  in #13
2. Then I created the command that calls the method from the lib

@sameo 

close  #11 