### PR TITLE
add missing unit tests

### DIFF
--- a/container/src/command.rs
+++ b/container/src/command.rs
@@ -42,3 +42,21 @@ impl From<&Option<Process>> for Command {
         command
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Command, Error};
+    use oci_spec::runtime::Process;
+
+    #[test]
+    fn test_command_from_process() -> Result<(), Error> {
+        let mut test_process = Process::default();
+
+        test_process.set_args(Some(vec!["echo".to_string(), "hello world".to_string()]));
+        let test_command = Command::from(&Some(test_process));
+        assert_eq!(test_command.arg0, "echo");
+        assert_eq!(test_command.args[0], "hello world");
+
+        Ok(())
+    }
+}

--- a/container/src/environment.rs
+++ b/container/src/environment.rs
@@ -32,3 +32,33 @@ impl From<&Option<Process>> for Environment {
         Environment { vars }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Environment, Error};
+    use oci_spec::runtime::Process;
+
+    #[test]
+    fn test_environment_from_process() -> Result<(), Error> {
+        let mut test_process = Process::default();
+        test_process.set_env(Some(vec![
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
+            "TERM=xterm".to_string(),
+        ]));
+        let test_environment = Environment::from(&Some(test_process));
+
+        assert_eq!(
+            test_environment.vars[0],
+            (
+                "PATH".to_string(),
+                "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()
+            )
+        );
+        assert_eq!(
+            test_environment.vars[1],
+            (("TERM".to_string(), "xterm".to_string()))
+        );
+
+        Ok(())
+    }
+}

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -115,7 +115,7 @@ impl Container {
 
 #[cfg(test)]
 mod tests {
-    use crate::Container;
+    use crate::{Container, Error};
     use proc_mounts::MountList;
     use tempdir::TempDir;
 
@@ -137,6 +137,12 @@ mod tests {
         let host_mounts_after_run_fail = MountList::new().unwrap();
         assert_eq!(host_mounts_before_run_fail, host_mounts_after_run_fail);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_container_with_invalid_oci_runtime_spec_file() -> Result<(), Error> {
+        assert!(Container::new("invalid_spec_file").is_err());
         Ok(())
     }
 }


### PR DESCRIPTION
This PR add several unit tests on kaps.

- Environment: test environment creation from process
- Container: test create container with invalid oci runtime spec file
- Command: test command creation from process
- Mounts: test apply and cleanup
closes #5 