### PR TITLE
container: Do not bind an empty return

### DIFF
--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -98,7 +98,7 @@ impl Container {
                 .code()
         };
 
-        let _ = &self.mounts.cleanup(self.rootfs.clone())?;
+        self.mounts.cleanup(self.rootfs.clone())?;
 
         if let Some(code) = code {
             if code != 0 {


### PR DESCRIPTION
We do not need to check for the mount cleanup value, when
it only returns a empty Result.

Signed-off-by: Samuel Ortiz <samuel.e.ortiz@protonmail.com>