### PR TITLE
Mounts cleanup

### DIFF
--- a/container/src/mounts.rs
+++ b/container/src/mounts.rs
@@ -19,8 +19,8 @@ impl Mounts {
     /// Apply some mounts.
     /// This method should be called before the container process execution in order to prepare
     /// & mount every mounts defined for it.
-    pub fn apply(mounts: &Mounts) -> Result<(), std::io::Error> {
-        for mount in &mounts.vec {
+    pub fn apply(&self) -> Result<(), std::io::Error> {
+        for mount in &self.vec {
             if let Some(code) = Command::new("mount")
                 .args(["-t", &mount.typ, &mount.source, &mount.destination])
                 .status()?

--- a/container/src/mounts.rs
+++ b/container/src/mounts.rs
@@ -12,7 +12,7 @@ struct Mount {
 
 #[derive(Clone)]
 pub struct Mounts {
-    vec: Vec<Mount>,
+    mounts: Vec<Mount>,
 }
 
 impl Mounts {
@@ -20,7 +20,7 @@ impl Mounts {
     /// This method should be called before the container process execution in order to prepare
     /// & mount every mounts defined for it.
     pub fn apply(&self) -> Result<(), std::io::Error> {
-        for mount in &self.vec {
+        for mount in &self.mounts {
             if let Some(code) = Command::new("mount")
                 .args(["-t", &mount.typ, &mount.source, &mount.destination])
                 .status()?
@@ -37,7 +37,7 @@ impl Mounts {
     /// Cleanup the mounts of a rootfs.
     /// This method should be called when a container has ended, to clean up the FS.
     pub fn cleanup(&self, rootfs: PathBuf) -> Result<(), crate::Error> {
-        for mount in &self.vec {
+        for mount in &self.mounts {
             let mut path = rootfs.clone();
             path.push(&mount.source);
 
@@ -64,7 +64,7 @@ impl Default for Mounts {
     /// Based on the OCI Specification
     fn default() -> Self {
         Mounts {
-            vec: vec![
+            mounts: vec![
                 Mount {
                     typ: String::from("devtmpfs"),
                     source: String::from("dev"),


### PR DESCRIPTION
* Make `apply` a method, not an associated function
* Use a more sensible name for the single `Mounts` field.